### PR TITLE
fix: Escape markdown

### DIFF
--- a/encodorbot.go
+++ b/encodorbot.go
@@ -30,7 +30,7 @@ const (
 	zalgoCommand = "/zalgo"
 )
 
-// newBot returns a configured telegram bot.
+// newBot returns a configured encodor bot.
 func newBot() *telebot.Bot {
 	settings := telebot.Settings{
 		Token:     os.Getenv(tokenEnvVar),
@@ -47,7 +47,7 @@ func newBot() *telebot.Bot {
 	return bot
 }
 
-// handleStart handles startCommand messages.
+// handleStart handles /start messages.
 func handleStart(c telebot.Context) error {
 	usage := fmt.Sprintf(`Usage:
 	[command] your message
@@ -59,7 +59,7 @@ Available Commands:
 	return c.Reply(usage)
 }
 
-// handleBeghilosz handles beghiloszCommand messages.
+// handleBeghilosz handles /beghilosz commands.
 func handleBeghilosz(c telebot.Context) error {
 	if c.Message().Payload == "" {
 		usage := fmt.Sprintf("To encode your message using calculator spelling send `%v YOUR MESSAGE`", beghiloszCommand)
@@ -69,7 +69,7 @@ func handleBeghilosz(c telebot.Context) error {
 	return c.Reply(helpers.EscapeMarkdownV2(encodedText, ""))
 }
 
-// handleZalgo handles zalgoCommand messages.
+// handleZalgo handles /zalgo commands.
 func handleZalgo(c telebot.Context) error {
 	if c.Message().Payload == "" {
 		usage := fmt.Sprintf("To encode your message using zalgo send `%v YOUR MESSAGE`", zalgoCommand)

--- a/encodorbot.go
+++ b/encodorbot.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kirillmorozov/encodor/beghilosz"
 	"github.com/kirillmorozov/encodor/cmd"
 	"github.com/kirillmorozov/encodor/zalgo"
+	"github.com/kirillmorozov/encodorbot/helpers"
 	"gopkg.in/telebot.v3"
 )
 
@@ -27,20 +28,6 @@ const (
 	beghiloszCommand = "/beghilosz"
 	// zalgoCommand is the command that's used to encode messages zalgo.
 	zalgoCommand = "/zalgo"
-)
-
-const (
-	// botUsage is format that explains bot usage.
-	botUsage = `Usage:
-	[command] your message
-
-Available Commands:
-	%v – Encode your message using calculator spelling
-	%v – Encode your message using zalgo`
-	// beghiloszUsage is a format string that expains beghiloszCommand usage.
-	beghiloszUsage = "To encode your message using calculator spelling send `%v YOUR MESSAGE`"
-	// zalgoUsage is a format string that expains zalgoCommand usage.
-	zalgoUsage = "To encode your message using zalgo send `%v YOUR MESSAGE`"
 )
 
 // newBot returns a configured telegram bot.
@@ -62,30 +49,37 @@ func newBot() *telebot.Bot {
 
 // handleStart handles startCommand messages.
 func handleStart(c telebot.Context) error {
-	return c.Reply(fmt.Sprintf(botUsage, beghiloszCommand, zalgoCommand))
+	usage := fmt.Sprintf(`Usage:
+	[command] your message
+
+Available Commands:
+	%v - Encode your message using calculator spelling
+	%v - Encode your message using zalgo`, beghiloszCommand, zalgoCommand)
+	usage = helpers.EscapeMarkdownV2(usage, "")
+	return c.Reply(usage)
 }
 
 // handleBeghilosz handles beghiloszCommand messages.
 func handleBeghilosz(c telebot.Context) error {
 	if c.Message().Payload == "" {
-		usage := fmt.Sprintf(beghiloszUsage, beghiloszCommand)
+		usage := fmt.Sprintf("To encode your message using calculator spelling send `%v YOUR MESSAGE`", beghiloszCommand)
 		return c.Reply(usage)
 	}
 	encodedText := beghilosz.Encode(c.Message().Payload)
-	return c.Reply(encodedText)
+	return c.Reply(helpers.EscapeMarkdownV2(encodedText, ""))
 }
 
 // handleZalgo handles zalgoCommand messages.
 func handleZalgo(c telebot.Context) error {
 	if c.Message().Payload == "" {
-		usage := fmt.Sprintf(zalgoUsage, zalgoCommand)
+		usage := fmt.Sprintf("To encode your message using zalgo send `%v YOUR MESSAGE`", zalgoCommand)
 		return c.Reply(usage)
 	}
 	encodedText, encodeErr := zalgo.Encode(c.Message().Payload, 3)
 	if encodeErr != nil {
 		return encodeErr
 	}
-	return c.Reply(encodedText)
+	return c.Reply(helpers.EscapeMarkdownV2(encodedText, ""))
 }
 
 // handleText handles all plain text messages.

--- a/encodorbot.go
+++ b/encodorbot.go
@@ -91,7 +91,7 @@ func handleText(c telebot.Context) error {
 	if encodeErr := encodorCmd.Execute(); encodeErr != nil {
 		return encodeErr
 	}
-	return c.Reply(output.String())
+	return c.Reply(helpers.EscapeMarkdownV2(output.String(), ""))
 }
 
 // HandleTelegramWebHook is the cloud function entry point.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kirillmorozov/encodorbot
 go 1.17
 
 require (
-	github.com/kirillmorozov/encodor v0.0.0-20220528131532-08ba9e7c2670
+	github.com/kirillmorozov/encodor v0.0.0-20220612223159-2ddf7f181db6
 	gopkg.in/telebot.v3 v3.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kirillmorozov/encodor v0.0.0-20220528131532-08ba9e7c2670 h1:Mx9uEzT/h8/xxJS3RbNDqY6HfQ+SzS/TIvk89nlPe3s=
 github.com/kirillmorozov/encodor v0.0.0-20220528131532-08ba9e7c2670/go.mod h1:+Em9P83u+0FD+9yS8gSol1upCZVEN0snfMZu0Osoyco=
+github.com/kirillmorozov/encodor v0.0.0-20220612223159-2ddf7f181db6 h1:izpaf03ma/eyj1M6u5q8yMFls1RrxPfKFJla1n48AbM=
+github.com/kirillmorozov/encodor v0.0.0-20220612223159-2ddf7f181db6/go.mod h1:Q8xKvvACKPcWlo6WXURBNEQuiCltm/qrK52MoYDFlXE=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/helpers/markdown.go
+++ b/helpers/markdown.go
@@ -6,8 +6,8 @@ import (
 	"gopkg.in/telebot.v3"
 )
 
-// escapeMarkdownV2 escapes telegram markup symbols.
-func escapeMarkdownV2(text string, entityType telebot.EntityType) string {
+// EscapeMarkdownV2 escapes telegram markup symbols.
+func EscapeMarkdownV2(text string, entityType telebot.EntityType) string {
 	var escapeChars string
 	switch entityType {
 	case telebot.EntityCode, telebot.EntityCodeBlock:

--- a/helpers/markdown.go
+++ b/helpers/markdown.go
@@ -1,10 +1,22 @@
 package helpers
 
 import (
+	"regexp"
+
 	"gopkg.in/telebot.v3"
 )
 
 // escapeMarkdownV2 escapes telegram markup symbols.
 func escapeMarkdownV2(text string, entityType telebot.EntityType) string {
-	return ""
+	var escapeChars string
+	switch entityType {
+	case telebot.EntityCode, telebot.EntityCodeBlock:
+		escapeChars = "\\`"
+	case telebot.EntityTextLink:
+		escapeChars = "\\)"
+	default:
+		escapeChars = "\\_*[]()~`>#+-=|{}.!"
+	}
+	re := regexp.MustCompilePOSIX("([{" + regexp.QuoteMeta(escapeChars) + "}])")
+	return re.ReplaceAllString(text, "\\$1")
 }

--- a/helpers/markdown.go
+++ b/helpers/markdown.go
@@ -1,0 +1,10 @@
+package helpers
+
+import (
+	"gopkg.in/telebot.v3"
+)
+
+// escapeMarkdownV2 escapes telegram markup symbols.
+func escapeMarkdownV2(text string, entityType telebot.EntityType) string {
+	return ""
+}

--- a/helpers/markdown.go
+++ b/helpers/markdown.go
@@ -7,6 +7,10 @@ import (
 )
 
 // EscapeMarkdownV2 escapes telegram markup symbols.
+// Use entityType argument to specify the type of text that needs to be escaped.
+// For the enitity types telebot.EntityCode, telebot.EntityCodeBlock and
+// telebot.EntityTextLink only certain characters need to be escaped.
+// See the official API documentation for details.
 func EscapeMarkdownV2(text string, entityType telebot.EntityType) string {
 	var escapeChars string
 	switch entityType {

--- a/helpers/markdown_test.go
+++ b/helpers/markdown_test.go
@@ -1,0 +1,61 @@
+package helpers
+
+import (
+	"testing"
+
+	"gopkg.in/telebot.v3"
+)
+
+func Test_escapeMarkdownV2(t *testing.T) {
+	type args struct {
+		text       string
+		entityType telebot.EntityType
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Empty text",
+			args: args{text: ``},
+			want: ``,
+		},
+		{
+			name: "Escape markdown v2",
+			args: args{text: `a_b*c[d]e (fg) h~I` + "`" + `>JK#L+MN -O=|p{qr}s.t!\ \u`},
+			want: `a\_b\*c\[d\]e \(fg\) h\~I\` + "`" + `\>JK\#L\+MN \-O\=\|p\{qr\}s\.t\!\\ \\u`,
+		},
+		{
+			name: "Monospaced code block",
+			args: args{
+				text:       `mono/pre: ` + "`" + `abc` + "`" + ` \int (` + "`" + `\some \` + "`" + `stuff)`,
+				entityType: telebot.EntityCodeBlock,
+			},
+			want: `mono/pre: \` + "`" + `abc\` + "`" + ` \\int (\` + "`" + `\\some \\\` + "`" + `stuff)`,
+		},
+		{
+			name: "Monospaced code",
+			args: args{
+				text:       `mono/pre: ` + "`" + `abc` + "`" + ` \int (` + "`" + `\some \` + "`" + `stuff)`,
+				entityType: telebot.EntityCode,
+			},
+			want: `mono/pre: \` + "`" + `abc\` + "`" + ` \\int (\` + "`" + `\\some \\\` + "`" + `stuff)`,
+		},
+		{
+			name: "Text link",
+			args: args{
+				text:       `https://url.containing/funny)cha)\\ra\\)cter\\s`,
+				entityType: telebot.EntityTextLink,
+			},
+			want: `https://url.containing/funny\)cha\)\\\\ra\\\\\)cter\\\\s`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeMarkdownV2(tt.args.text, tt.args.entityType); got != tt.want {
+				t.Errorf("escapeMarkdownV2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/helpers/markdown_test.go
+++ b/helpers/markdown_test.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/telebot.v3"
 )
 
-func Test_escapeMarkdownV2(t *testing.T) {
+func Test_EscapeMarkdownV2(t *testing.T) {
 	type args struct {
 		text       string
 		entityType telebot.EntityType
@@ -53,7 +53,7 @@ func Test_escapeMarkdownV2(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := escapeMarkdownV2(tt.args.text, tt.args.entityType); got != tt.want {
+			if got := EscapeMarkdownV2(tt.args.text, tt.args.entityType); got != tt.want {
 				t.Errorf("escapeMarkdownV2() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Escape all characters that are required by Telegram Markdown V2 spec in
bot's replies.